### PR TITLE
Update tests to pass more configurations

### DIFF
--- a/addon/handler/archive/archive_test.go
+++ b/addon/handler/archive/archive_test.go
@@ -6,19 +6,59 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/nulab/go-git-http-xfer/githttpxfer"
 )
 
-func Test_it_should_download_archive_repository(t *testing.T) {
+type ArchiveParams struct {
+	gitRootPath string
+	gitBinPath  string
+	repoName    string
+	head        string
+}
 
-	if _, err := exec.LookPath("git"); err != nil {
-		t.Log("git is not found. so skip git archive test.")
-		return
+var (
+	archiveParams *ArchiveParams
+)
+
+func setupArchiveTest(t *testing.T) error {
+
+	gitBinPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Log("git is not found. so skip git e2e test.")
+		return err
 	}
 
-	ghx, err := githttpxfer.New("/data/git", "/usr/bin/git")
+	archiveParams = new(ArchiveParams)
+
+	gitRootPath, err := ioutil.TempDir("", "githttpxfer")
+	if err != nil {
+		t.Logf("get temp directory failed, err: %v", err)
+		return err
+	}
+	os.Chdir(gitRootPath)
+	archiveParams.gitRootPath = gitRootPath
+	archiveParams.gitBinPath = gitBinPath
+	archiveParams.repoName = "test.git"
+	archiveParams.head = "master"
+
+	return nil
+}
+
+func teardownArchiveTest() {
+	os.RemoveAll(archiveParams.gitRootPath)
+}
+
+func Test_it_should_download_archive_repository(t *testing.T) {
+
+	if err := setupArchiveTest(t); err != nil {
+		return
+	}
+	defer teardownArchiveTest()
+
+	ghx, err := githttpxfer.New(archiveParams.gitRootPath, archiveParams.gitBinPath)
 	if err != nil {
 		t.Errorf("An instance could not be created. %s", err.Error())
 		return
@@ -38,7 +78,7 @@ func Test_it_should_download_archive_repository(t *testing.T) {
 
 	repoName := "archive_test.git"
 	absRepoPath := ghx.Git.GetAbsolutePath(repoName)
-	os.Mkdir(absRepoPath, os.ModeDir)
+	os.Mkdir(absRepoPath, os.ModeDir|os.ModePerm)
 
 	if _, err := execCmd(absRepoPath, "git", "init", "--bare", "--shared"); err != nil {
 		t.Errorf("execute command error: %s", err.Error())
@@ -81,17 +121,29 @@ func Test_it_should_download_archive_repository(t *testing.T) {
 		return
 	}
 
-	if _, err := execCmd(destDir, "git", "push", "-u", "origin", "master"); err != nil {
+	output, err := ioutil.ReadFile(path.Join(destDir, ".git/HEAD"))
+	if err != nil {
 		t.Errorf("execute command error: %s", err.Error())
 		return
 	}
 
-	if _, err := execCmd(destDir, "wget", "-O-", remoteRepoUrl+"/archive/master.zip"); err != nil {
+	archiveParams.head = strings.Join(strings.Split(strings.TrimSuffix(string(output), "\n"), "/")[2:], "/")
+	if archiveParams.head == "" {
+		t.Error("could not figure out HEAD")
+		return
+	}
+
+	if _, err := execCmd(destDir, "git", "push", "-u", "origin", archiveParams.head); err != nil {
 		t.Errorf("execute command error: %s", err.Error())
 		return
 	}
 
-	if _, err := execCmd(destDir, "wget", "-O-", remoteRepoUrl+"/archive/master.tar"); err != nil {
+	if _, err := execCmd(destDir, "wget", "-O-", remoteRepoUrl+"/archive/"+archiveParams.head+".zip"); err != nil {
+		t.Errorf("execute command error: %s", err.Error())
+		return
+	}
+
+	if _, err := execCmd(destDir, "wget", "-O-", remoteRepoUrl+"/archive/"+archiveParams.head+".tar"); err != nil {
 		t.Errorf("execute command error: %s", err.Error())
 		return
 	}

--- a/githttpxfer/context_test.go
+++ b/githttpxfer/context_test.go
@@ -1,0 +1,64 @@
+package githttpxfer
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var testContext Context
+
+func setupContextTest(t *testing.T) error {
+	request, _ := http.NewRequest(http.MethodGet, "http://localhost:8080", nil)
+	recorder := httptest.NewRecorder()
+	testContext = NewContext(recorder, request, "test.git", "")
+	return nil
+}
+
+func teardownContextTest() {
+}
+
+func Test_Context_methods_should_succeed(t *testing.T) {
+	err := setupContextTest(t)
+	if err != nil {
+		t.Errorf("error with setupContextTest: %v", err)
+		return
+	}
+	defer teardownContextTest()
+
+	response := testContext.Response()
+	if response == nil {
+		t.Error("response should not be nil")
+	}
+
+	request := testContext.Request()
+	if request.Method == http.MethodGet &&
+		request.URL.Path == "/" {
+		t.Error("request should be a GET on /")
+	}
+
+	testContext.SetRequest(request)
+	request = testContext.Request()
+	if request.Method == http.MethodGet &&
+		request.URL.Path == "/" {
+		t.Error("request should be a GET on /")
+	}
+
+	testContext.SetRepoPath("/tmp")
+	repopath := testContext.RepoPath()
+	if repopath != "/tmp" {
+		t.Error("repopath should be /tmp")
+	}
+
+	testContext.SetFilePath("/tmp/file")
+	filepath := testContext.FilePath()
+	if filepath != "/tmp/file" {
+		t.Error("filepath should be /tmp/file")
+	}
+
+	testContext.SetEnv([]string{"key=value"})
+	env := testContext.Env()
+	if env[0] != "key=value" {
+		t.Error("env should be key=value")
+	}
+}

--- a/githttpxfer/git_test.go
+++ b/githttpxfer/git_test.go
@@ -10,6 +10,12 @@ import (
 
 func Test_Git_getRequestFileInfo_should_return_RequestFileInfo(t *testing.T) {
 
+	gitBinPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Errorf("git is not found.")
+		return
+	}
+
 	gitRootPath, err := ioutil.TempDir("", "githttpxfer")
 	if err != nil {
 		t.Errorf("Create Temp Dir error: %s", err.Error())
@@ -17,13 +23,13 @@ func Test_Git_getRequestFileInfo_should_return_RequestFileInfo(t *testing.T) {
 	}
 	defer os.RemoveAll(gitRootPath)
 
-	git := newGit(gitRootPath, "/usr/bin/git", true, true)
+	git := newGit(gitRootPath, gitBinPath, true, true)
 
 	repoPath := "foo"
 	filePath := "README.txt"
 
 	absRepoPath := git.GetAbsolutePath(repoPath)
-	os.Mkdir(absRepoPath, os.ModeDir)
+	os.Mkdir(absRepoPath, os.ModeDir|os.ModePerm)
 
 	touchCmd := exec.Command("touch", filePath)
 	touchCmd.Dir = absRepoPath
@@ -40,6 +46,12 @@ func Test_Git_getRequestFileInfo_should_return_RequestFileInfo(t *testing.T) {
 
 func Test_Git_getRequestFileInfo_should_not_return_RequestFileInfo(t *testing.T) {
 
+	gitBinPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Errorf("git is not found.")
+		return
+	}
+
 	gitRootPath, err := ioutil.TempDir("", "githttpxfer")
 	if err != nil {
 		t.Errorf("Create Temp Dir error: %s", err.Error())
@@ -47,7 +59,7 @@ func Test_Git_getRequestFileInfo_should_not_return_RequestFileInfo(t *testing.T)
 	}
 	defer os.RemoveAll(gitRootPath)
 
-	git := newGit(gitRootPath, "/usr/bin/git", true, true)
+	git := newGit(gitRootPath, gitBinPath, true, true)
 
 	repoPath := "foo"
 	filePath := "README.txt"
@@ -60,6 +72,12 @@ func Test_Git_getRequestFileInfo_should_not_return_RequestFileInfo(t *testing.T)
 
 func Test_Git_exists_should_return_true_if_exists_repository(t *testing.T) {
 
+	gitBinPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Errorf("git is not found.")
+		return
+	}
+
 	gitRootPath, err := ioutil.TempDir("", "githttpxfer")
 	if err != nil {
 		t.Errorf("Create Temp Dir error: %s", err.Error())
@@ -67,11 +85,11 @@ func Test_Git_exists_should_return_true_if_exists_repository(t *testing.T) {
 	}
 	defer os.RemoveAll(gitRootPath)
 
-	git := newGit(gitRootPath, "/usr/bin/git", true, true)
+	git := newGit(gitRootPath, gitBinPath, true, true)
 
 	repoPath := "foo"
 
-	os.Mkdir(path.Join(gitRootPath, repoPath), os.ModeDir)
+	os.Mkdir(path.Join(gitRootPath, repoPath), os.ModeDir|os.ModePerm)
 
 	if !git.Exists(repoPath) {
 		t.Errorf("this repository is not exists. path: %s", git.GetAbsolutePath(repoPath))
@@ -81,6 +99,12 @@ func Test_Git_exists_should_return_true_if_exists_repository(t *testing.T) {
 
 func Test_Git_exists_should_return_false_if_not_exists_repository(t *testing.T) {
 
+	gitBinPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Errorf("git is not found.")
+		return
+	}
+
 	gitRootPath, err := ioutil.TempDir("", "githttpxfer")
 	if err != nil {
 		t.Errorf("Create Temp Dir error: %s", err.Error())
@@ -88,7 +112,7 @@ func Test_Git_exists_should_return_false_if_not_exists_repository(t *testing.T) 
 	}
 	defer os.RemoveAll(gitRootPath)
 
-	git := newGit(gitRootPath, "/usr/bin/git", true, true)
+	git := newGit(gitRootPath, gitBinPath, true, true)
 
 	repoPath := "foo"
 
@@ -100,6 +124,12 @@ func Test_Git_exists_should_return_false_if_not_exists_repository(t *testing.T) 
 
 func Test_Git_getAbsolutePath_should_return_absolute_path_of_git_repository(t *testing.T) {
 
+	gitBinPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Errorf("git is not found.")
+		return
+	}
+
 	gitRootPath, err := ioutil.TempDir("", "githttpxfer")
 	if err != nil {
 		t.Errorf("Create Temp Dir error: %s", err.Error())
@@ -107,7 +137,7 @@ func Test_Git_getAbsolutePath_should_return_absolute_path_of_git_repository(t *t
 	}
 	defer os.RemoveAll(gitRootPath)
 
-	git := newGit(gitRootPath, "/usr/bin/git", true, true)
+	git := newGit(gitRootPath, gitBinPath, true, true)
 
 	repoPath := "foo"
 	expectedPath := path.Join(gitRootPath, repoPath)

--- a/githttpxfer/githttpxfer_test.go
+++ b/githttpxfer/githttpxfer_test.go
@@ -1,19 +1,63 @@
 package githttpxfer
 
 import (
-	"log"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"os/exec"
 	"testing"
 )
 
+type TestParams struct {
+	gitRootPath string
+	gitBinPath  string
+	repoName    string
+}
+
+var (
+	testParams *TestParams
+)
+
+func setupTest(t *testing.T) error {
+
+	gitBinPath, err := exec.LookPath("git")
+	if err != nil {
+		t.Log("git is not found. so skip git e2e test.")
+		return err
+	}
+
+	testParams = new(TestParams)
+
+	gitRootPath, err := ioutil.TempDir("", "githttpxfer")
+	if err != nil {
+		t.Logf("get temp directory failed, err: %v", err)
+		return err
+	}
+	os.Chdir(gitRootPath)
+	testParams.gitRootPath = gitRootPath
+	testParams.gitBinPath = gitBinPath
+	testParams.repoName = "test.git"
+	err = os.Mkdir(testParams.repoName, os.ModeDir|os.ModePerm)
+	if err != nil {
+		t.Logf("get temp directory failed, err: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func teardownTest() {
+	os.RemoveAll(testParams.gitRootPath)
+}
+
 func Test_GitHTTPXfer_GitHTTPXferOption(t *testing.T) {
 
-	if _, err := exec.LookPath("git"); err != nil {
-		log.Println("git is not found. so skip test.")
+	if err := setupTest(t); err != nil {
+		return
 	}
+	defer teardownTest()
 
 	tests := []struct {
 		description       string
@@ -42,14 +86,15 @@ func Test_GitHTTPXfer_GitHTTPXferOption(t *testing.T) {
 
 		t.Log(tc.description)
 
-		ghx, err := New("/data/git", "/usr/bin/git", tc.gitHTTPXferOption)
+		ghx, err := New(testParams.gitRootPath, testParams.gitBinPath, tc.gitHTTPXferOption)
 		if err != nil {
 			t.Errorf("GitHTTPXfer instance could not be created. %s", err.Error())
 		}
 
 		ts := httptest.NewServer(ghx)
 		if ts == nil {
-			t.Error("test server is nil.")
+			t.Log("test server is nil.")
+			t.FailNow()
 		}
 
 		res, err := http.Post(
@@ -70,9 +115,15 @@ func Test_GitHTTPXfer_GitHTTPXferOption(t *testing.T) {
 }
 
 func Test_GitHTTPXfer_MatchRouting_should_not_match(t *testing.T) {
+
+	if err := setupEndToEndTest(t); err != nil {
+		return
+	}
+	defer teardownEndToEndTest()
+
 	t.Log("it should not match if http method is different")
 	var err error
-	ghx, err := New("", "/usr/bin/git")
+	ghx, err := New(testParams.gitRootPath, testParams.gitBinPath)
 	if err != nil {
 		t.Errorf("GitHTTPXfer instance could not be created. %s", err.Error())
 		return
@@ -93,7 +144,13 @@ func Test_GitHTTPXfer_MatchRouting_should_not_match(t *testing.T) {
 }
 
 func Test_GitHTTPXfer_MatchRouting_should_match(t *testing.T) {
-	ghx, err := New("", "/usr/bin/git")
+
+	if err := setupEndToEndTest(t); err != nil {
+		return
+	}
+	defer teardownEndToEndTest()
+
+	ghx, err := New(testParams.gitRootPath, testParams.gitBinPath)
 	if err != nil {
 		t.Errorf("GitHTTPXfer instance could not be created. %s", err.Error())
 		return

--- a/githttpxfer/githttpxfer_test.go
+++ b/githttpxfer/githttpxfer_test.go
@@ -80,6 +80,13 @@ func Test_GitHTTPXfer_GitHTTPXferOption(t *testing.T) {
 			expectedCode:      403,
 			gitHTTPXferOption: DisableReceivePack(),
 		},
+		{
+			description:       "it should return 404 if project does not exist",
+			url:               "/unknown.git/git-receive-pack",
+			contentsType:      "application/x-git-receive-pack-request",
+			expectedCode:      404,
+			gitHTTPXferOption: DisableReceivePack(),
+		},
 	}
 
 	for _, tc := range tests {

--- a/githttpxfer/router_test.go
+++ b/githttpxfer/router_test.go
@@ -45,7 +45,7 @@ func Test_Router_Match_should_match_route(t *testing.T) {
 	if http.MethodPost != route.Method {
 		t.Errorf("http method is not %s . result: %s", http.MethodPost, route.Method)
 	}
-	if "foo" != match.FilePath {
+	if match.FilePath != "foo" {
 		t.Errorf("match is not %s . result: %s", "foo", match.FilePath)
 	}
 }


### PR DESCRIPTION
This PR changes your tests (only tests!) for a few reasons:

- the default `HEAD` has changed from `master` to `main` in new git versions. Tests now read `.git/HEAD` to get the right pattern
- All files are now created in temporary directories instead of `/data/git` in some cases
- temporary directories are created without permissions on MacOS. The addition of `os.ModePerm` fixes it 
- temporary directories are now removed at the end of every tests to rerun them as wanted
- a complete configuration is reset on every test so that we can run them independently
- `git` might not be located in `/usr/bin` on some OS or because you want to use a custom `git` version

Your repository is really awesome. Thank a lot for sharing!